### PR TITLE
Rename inertia I -> In to avoid conflict with complex.h

### DIFF
--- a/src/Utils/Utils/Geometry/GeometryUtilities.cpp
+++ b/src/Utils/Utils/Geometry/GeometryUtilities.cpp
@@ -115,17 +115,17 @@ Eigen::Matrix3d calculateInertiaTensor(const PositionCollection& positions, cons
     Ixz -= m * x * z;
     Iyz -= m * y * z;
   }
-  Eigen::Matrix3d I;
-  I << Ixx, Ixy, Ixz, Ixy, Iyy, Iyz, Ixz, Iyz, Izz;
-  return I;
+  Eigen::Matrix3d In;
+  In << Ixx, Ixy, Ixz, Ixy, Iyy, Iyz, Ixz, Iyz, Izz;
+  return In;
 }
 
 PrincipalMomentsOfInertia calculatePrincipalMoments(const PositionCollection& positions,
                                                     const std::vector<double>& masses, const Position& centerOfMass) {
-  auto I = calculateInertiaTensor(positions, masses, centerOfMass);
+  auto In = calculateInertiaTensor(positions, masses, centerOfMass);
 
   Eigen::SelfAdjointEigenSolver<Eigen::Matrix3d> es;
-  es.compute(I);
+  es.compute(In);
 
   PrincipalMomentsOfInertia pmi;
   pmi.eigenvalues = es.eigenvalues();


### PR DESCRIPTION
When Eigen3 is configured to link with a LAPACKE library (`-DEIGEN_USE_LAPACKE`), `complex.h` gets pulled in, which defines `I` to be the imaginary number. (Incidentally, linking Sparrow against OpenBLAS through Eigen3 seems to make the code significantly slower, not faster.)

This is also a problem in googletest, which uses `I` in [`gtest/gtest-printers.h`](https://github.com/google/googletest/blob/master/googletest/include/gtest/gtest-printers.h#L626). A workaround is to set `SCINE_BUILD_TESTS` (and possibly `BUILD_GMOCK` and/or `INSTALL_GTEST`) to `OFF`.